### PR TITLE
chore(github): add issue templates for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: Skittyblock
+
+---
+
+### Summary
+
+Summarize the bug encountered concisely.
+
+### Steps to reproduce
+
+Describe how one can reproduce the issue — this is crucial. Please use an ordered list.
+
+### What is the current *bug* behavior?
+
+Describe what actually happens.
+
+### What is the expected *correct* behavior?
+
+Describe what you should see instead.
+
+### Relevant log output and/or screenshots
+
+Paste any relevant log output — please use code blocks (```) to format log output and code, as it’s tough to
+read otherwise.
+
+### System Information
+
+- **OS**: [e.g. iOS, Mac]
+- **Version**: [e.g. main branch, TestFlight v0.7]
+
+### Possible fixes
+
+If you can, link to the line of code that might be responsible for the problem.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,8 +30,10 @@ read otherwise.
 
 ### System Information
 
-- **OS**: [e.g. iOS, Mac]
-- **Version**: [e.g. main branch, TestFlight v0.7]
+- **Device**: [e.g., iPhone 15 Pro, M1 iPad Pro, MacBook Air M2]
+- **OS**: [e.g., iOS, iPadOS, macOS]
+- **OS Version**: [e.g., 18.6 or 15 Sequoia]
+- **App Version**: [e.g., main branch, v0.7]
 
 ### Possible fixes
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: enhancement
+assignees: Skittyblock
+
+---
+
+### Summary
+
+Provide a concise description of the feature you’d like to see added.
+
+### Use Case
+
+Explain the problem this feature solves or the benefit it provides. Why would this be valuable?
+
+### Proposed Implementation
+
+Describe how you envision this feature working. Include as much detail as possible (e.g., UI changes, functionality,
+workflow).
+
+### Alternatives Considered
+
+If applicable, mention any alternative solutions or workarounds you’ve thought of and why they’re less ideal.
+
+### Additional Context or Mockups
+
+Add any supporting details, such as sketches, screenshots, or examples from other projects. Use code blocks (```) for
+code snippets if relevant.
+
+### System Information (if applicable)
+
+- **Device**: [e.g., iPhone 15 Pro, M1 iPad Pro, MacBook Air M2]
+- **OS**: [e.g., iOS, iPadOS, macOS]
+- **OS Version**: [e.g., 18.6 or 15 Sequoia]
+- **App Version**: [e.g., main branch, v0.7]


### PR DESCRIPTION
Adds templates to guide users when creating issues and to automatically apply the `bug` and `enhancement` labels.